### PR TITLE
Removed base encoding

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,7 +11,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cors());
 
 const authCheck = jwt({
-  secret: new Buffer('YOUR-AUTH0-CLIENT-SECRET', 'base64'),
+  secret: 'YOUR-AUTH0-CLIENT-SECRET',
   audience: 'YOUR-AUTH0-CLIENT-ID'
 });
 


### PR DESCRIPTION
Didn't worked for me with "new Buffer('YOUR-AUTH0-CLIENT-SECRET', 'base64')". I copied the client secret directly from the management gui.