### PR TITLE
Updated README.md to mention Implicit flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Daily Deals
 
-Daily Deals is an application built with Angular that shows how you can add token based authentication to your Angular applications. You can read the full tutorial for this project here: [Angular Authentication Tutorial](https://auth0.com/blog/angular-2-authentication/).
+Daily Deals is an application built with Angular that shows how you can add token based authentication using the [Implicit flow](https://auth0.com/docs/flows/concepts/implicit) to your Angular applications. You can read the full tutorial for this project here: [Angular Authentication Tutorial](https://auth0.com/blog/angular-2-authentication/).
 
 # Running the App
 


### PR DESCRIPTION
Make it clear in README.md that this example project demonstrates the use of Implicit flow, not the Authorisation Code flow with PKCE which is now the recommended way to do authentication for SPAs according to https://auth0.com/docs/api-auth/which-oauth-flow-to-use.